### PR TITLE
Try lun for hd type

### DIFF
--- a/src/MassStorageDriver.cpp
+++ b/src/MassStorageDriver.cpp
@@ -373,7 +373,7 @@ uint8_t msController::msGetCSW() {
 //---------------------------------------------------------------------------
 // Process Possible Errors
 uint8_t msController::msProcessError(uint8_t msStatus) {
-	uint8_t msResult = 0;
+	//uint8_t msResult = 0;
 	switch(msStatus) {
 		case 0:
 			return MS_CBW_PASS;

--- a/src/MassStorageHost.cpp
+++ b/src/MassStorageHost.cpp
@@ -30,6 +30,24 @@
 #include "msc.h"
 #include "MassStorage.h"
 
+//#define DEBUG_MSC
+//#define DEBUG_MSC_VERBOSE
+
+#ifndef DEBUG_MSC
+#undef DEBUG_MSC_VERBOSE
+void inline DBGPrintf(...) {};
+#else
+#define DBGPrintf Serial.printf
+#endif
+
+#ifndef DEBUG_MSC_VERBOSE
+void inline VDBGPrintf(...) {};
+void inline DBGHexDump(const void *ptr, uint32_t len) {};
+#else
+#define VDBGPrintf Serial.printf
+#define DBGHexDump hexDump
+#endif
+
 //#define print   USBHost::print_
 //#define println USBHost::println_
 
@@ -77,9 +95,9 @@ uint8_t mscInit(void) {
 	while(!msDrive1.available());
 	msDrive1.msReset();
 	delay(1000);
-	Serial.printf("## mscInit before msgGetMaxLun: %d\n", msResult);
+	DBGPrintf("## mscInit before msgGetMaxLun: %d\n", msResult);
 	uint8_t maxLUN = msDrive1.msGetMaxLun();
-	Serial.printf("## mscInit after msgGetMaxLun: %d\n", msResult);
+	DBGPrintf("## mscInit after msgGetMaxLun: %d\n", msResult);
 	delay(150);
 	//-------------------------------------------------------
 //	msDrive1.msStartStopUnit(0);
@@ -87,29 +105,32 @@ uint8_t mscInit(void) {
 	if(msResult)
 		return msResult;
 //	msResult = getDriveSense(&msSense);
-//	hexDump(&msSense,sizeof(msSense));
+//	DBGHexDump(&msSense,sizeof(msSense));
 
 	// Test to see if multiple LUN see if we find right data...
 	for (uint8_t currentLUN=0; currentLUN <= maxLUN; currentLUN++) {
 		msDrive1.msCurrentLun(currentLUN);
 
 		msResult = msDrive1.msDeviceInquiry(&msInquiry);
-		Serial.printf("## mscInit after msDeviceInquiry LUN(%d): Device Type: %d result:%d\n", currentLUN, msInquiry.DeviceType, msResult);
+		DBGPrintf("## mscInit after msDeviceInquiry LUN(%d): Device Type: %d result:%d\n", currentLUN, msInquiry.DeviceType, msResult);
 		if(msResult)
 			return msResult;
-		hexDump(&msInquiry,sizeof(msInquiry));
+		DBGHexDump(&msInquiry,sizeof(msInquiry));
 		if (msInquiry.DeviceType == 0)
 			break;
 	} 
 
+	// if device is not like hard disk, probably won't work! example CDROM... 
+	if (msInquiry.DeviceType != 0)
+		return MS_CSW_TAG_ERROR;
 
 
 	//-------------------------------------------------------
 	msResult = msDrive1.msReadDeviceCapacity(&msCapacity);
-	Serial.printf("## mscInit after msReadDeviceCapacity: %d\n", msResult);
+	DBGPrintf("## mscInit after msReadDeviceCapacity: %d\n", msResult);
 	if(msResult)
 		return msResult;
-	hexDump(&msCapacity,sizeof(msCapacity));
+	DBGHexDump(&msCapacity,sizeof(msCapacity));
 	return msResult;
 }
 

--- a/src/MassStorageHost.cpp
+++ b/src/MassStorageHost.cpp
@@ -78,7 +78,7 @@ uint8_t mscInit(void) {
 	msDrive1.msReset();
 	delay(1000);
 	Serial.printf("## mscInit before msgGetMaxLun: %d\n", msResult);
-	msResult = msDrive1.msGetMaxLun();
+	uint8_t maxLUN = msDrive1.msGetMaxLun();
 	Serial.printf("## mscInit after msgGetMaxLun: %d\n", msResult);
 	delay(150);
 	//-------------------------------------------------------
@@ -89,14 +89,27 @@ uint8_t mscInit(void) {
 //	msResult = getDriveSense(&msSense);
 //	hexDump(&msSense,sizeof(msSense));
 
+	// Test to see if multiple LUN see if we find right data...
+	for (uint8_t currentLUN=0; currentLUN <= maxLUN; currentLUN++) {
+		msDrive1.msCurrentLun(currentLUN);
 
-	msResult = msDrive1.msDeviceInquiry(&msInquiry);
-	if(msResult)
-		return msResult;
+		msResult = msDrive1.msDeviceInquiry(&msInquiry);
+		Serial.printf("## mscInit after msDeviceInquiry LUN(%d): Device Type: %d result:%d\n", currentLUN, msInquiry.DeviceType, msResult);
+		if(msResult)
+			return msResult;
+		hexDump(&msInquiry,sizeof(msInquiry));
+		if (msInquiry.DeviceType == 0)
+			break;
+	} 
+
+
+
 	//-------------------------------------------------------
 	msResult = msDrive1.msReadDeviceCapacity(&msCapacity);
+	Serial.printf("## mscInit after msReadDeviceCapacity: %d\n", msResult);
 	if(msResult)
 		return msResult;
+	hexDump(&msCapacity,sizeof(msCapacity));
 	return msResult;
 }
 

--- a/src/msc.h
+++ b/src/msc.h
@@ -38,6 +38,8 @@ public:
 	msController(USBHost *host) { init(); }
 	void msReset();
 	uint8_t msGetMaxLun();
+	void msCurrentLun(uint8_t lun) {currentLUN = lun;}
+	uint8_t msCurrentLun() {return currentLUN;}
 	bool available() { delay(0); return deviceAvailable; }
 	bool initialized() { delay(0); return deviceInitialized; }
 	uint8_t WaitMediaReady();


### PR DESCRIPTION
I had at least one drive that would not work as the maxLUN=1 
and the first LUN was defined for a virtual CDROM drive, that probably contained utilities to work with that drive... LUN=1 was the actual hard drive.

The code now loops through the valid LUNs calling msDeviceInquiry until it finds a device type = 0.  If none found it will error out.  Case of CDROM for example.

This made my 1TB Toshiba hard disk work. 

I also added in some defines and the like to make some of the debug messages (Serial.printf...) calls to be conditional... You define a #define ... at start of file and they will output, undefine it and they will reduce to no code. 